### PR TITLE
Add Python 2.7 required package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:
 
 setup(
     name='uber_rides',
-    version='0.2.1',
+    version='0.2.2',
     packages=find_packages(),
     description='Official Uber Rides API Python SDK',
     long_description=readme,
@@ -21,6 +21,9 @@ setup(
     author='Uber Technologies, Inc.',
     author_email='christinek@uber.com',
     install_requires=['requests', 'pyyaml'],
+    extras_require={
+        ':python_version == "2.7"': ['future'],
+    },
     tests_require=['pytest', 'mock', 'vcrpy'],
     keywords=['uber', 'api', 'sdk', 'rides', 'library'],
 )


### PR DESCRIPTION
When following the install instructions on Python 2.7 and trying to run the example app, an error is thrown with a missing import:

    rides-python-sdk$ python example/authorization_code_grant.py 
    Traceback (most recent call last):
      File "example/authorization_code_grant.py", line 41, in <module>
        from builtins import input
    ImportError: No module named builtins

This pull request adds the missing `future` package.