### PR TITLE
Add request scope to example app

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -4,3 +4,4 @@ redirect_url: INSERT_REDIRECT_URL_HERE
 scopes:
     - profile
     - history
+    - request


### PR DESCRIPTION
The example app `request_surge_ride.py` fails when trying to run out of the box. This is due to a missing scope `request` in the OAuth config.

    rides-python-sdk$ python example/request_surge_ride.py 
    
    Ride estimates before surge.
    
     {u'price': {u'surge_confirmation_href': None, u'high_estimate': 15, u'minimum': 7, u'surge_confirmation_id': None, u'low_estimate': 12, u'surge_multiplier': 1.0, u'display': u'$12-15', u'currency_code': u'USD'}, u'trip': {u'distance_unit': u'mile', u'duration_estimate': 1140, u'distance_estimate': 4.54}, u'pickup_estimate': 2} 
    
    Activate surge.
    
     204 
    
    Ride estimates after surge.
    
     {u'price': {u'surge_confirmation_href': u'https://sandbox-api.uber.com/v1/surge-confirmations/afcadd90-2e24-43e1-bc3f-8e2a40f0ed38', u'high_estimate': 30, u'minimum': 12, u'surge_confirmation_id': u'afcadd90-2e24-43e1-bc3f-8e2a40f0ed38', u'low_estimate': 24, u'surge_multiplier': 2.0, u'display': u'$24-30', u'currency_code': u'USD'}, u'trip': {u'distance_unit': u'mile', u'duration_estimate': 1140, u'distance_estimate': 4.54}, u'pickup_estimate': 2} 
    
    Request a ride with surging product.
    
     The request contains bad syntax or cannot be filled due to a fault from the client sending the request. 
    
    ...

