### PR TITLE
Make ErrorDetails dumpable, print errors array when failing.

### DIFF
--- a/example/utils.py
+++ b/example/utils.py
@@ -74,14 +74,15 @@ def response_print(message):
     print(COLORS.response, message, COLORS.end)
 
 
-def fail_print(message):
+def fail_print(error):
     """Print a message in red text.
 
     Parameters
         message (str)
             Message to print.
     """
-    print(COLORS.fail, message, COLORS.end)
+    print(COLORS.fail, error.message, COLORS.end)
+    print(COLORS.fail, error.errors, COLORS.end)
 
 
 def paragraph_print(message):

--- a/uber_rides/errors.py
+++ b/uber_rides/errors.py
@@ -152,6 +152,8 @@ class ErrorDetails(object):
         self.code = code
         self.title = title
 
+    def __repr__(self):
+        return "ErrorDetails: {} {} {}".format(str(self.status), str(self.code), str(self.title))
 
 class UnknownHttpError(APIError):
     """Throw when an unknown HTTP error occurs.


### PR DESCRIPTION
The error message `The request contains bad syntax or cannot be filled due to a fault from the client sending the request.` is not very descriptive when a `ClientError` occurs. Also, trying to print the `errors` array results in:

    <uber_rides.errors.ErrorDetails object at 0x10e630690>

This pull request adds a string representation for `ErrorDetails` so it is easily dumped. This pull request also prints out the `errors` array in `fail_print()` in the example app to give the user more details. For example:

    The request contains bad syntax or cannot be filled due to a fault from the client sending the request. 
    [ErrorDetails: 401 unauthorized Missing scope: request] 