### PR TITLE
Update error handlers to pass response body as error message

### DIFF
--- a/uber_rides/utils/handlers.py
+++ b/uber_rides/utils/handlers.py
@@ -49,9 +49,15 @@ def error_handler(response, **kwargs):
             The original HTTP response from the API request.
     """
     if 400 <= response.status_code <= 499:
-        raise ClientError(response)
+        error_status_code = response.status_code
+        error_body = response.json().get('message')
+        error_message = str(error_status_code) + ': ' + error_body
+        raise ClientError(response, error_message)
 
     elif 500 <= response.status_code <= 599:
-        raise ServerError(response)
+        error_status_code = response.status_code
+        error_body = response.json().get('message')
+        error_message = str(error_status_code) + ': ' + error_body
+        raise ServerError(response, error_message)
 
     return response

--- a/uber_rides/utils/handlers.py
+++ b/uber_rides/utils/handlers.py
@@ -26,6 +26,8 @@ from __future__ import unicode_literals
 from uber_rides.errors import ClientError
 from uber_rides.errors import ServerError
 
+from json import JSONDecodeError
+
 
 def error_handler(response, **kwargs):
     """Error Handler to surface 4XX and 5XX errors.
@@ -48,16 +50,18 @@ def error_handler(response, **kwargs):
         response (requests.Response)
             The original HTTP response from the API request.
     """
-    if 400 <= response.status_code <= 499:
-        error_status_code = response.status_code
-        error_body = response.json().get('message')
-        error_message = str(error_status_code) + ': ' + error_body
+    try:
+        body = response.json()
+    except JSONDecodeError:
+        body = {}
+    status_code = response.status_code
+    message = body.get('message', '')
+    fields = body.get('fields', '')
+    error_message = str(status_code) + ': ' + message + ' ' + str(fields)
+    if 400 <= status_code <= 499:
         raise ClientError(response, error_message)
 
-    elif 500 <= response.status_code <= 599:
-        error_status_code = response.status_code
-        error_body = response.json().get('message')
-        error_message = str(error_status_code) + ': ' + error_body
+    elif 500 <= status_code <= 599:
         raise ServerError(response, error_message)
 
     return response


### PR DESCRIPTION
Fixes #23 by passing the status code and message of the response from the API to the ClientError/ServerError to override the default message.
The error messages look like this now:
`uber_rides.errors.ClientError: 401: Invalid OAuth 2.0 credentials provided.`
`uber_rides.errors.ClientError: 422: Invalid request {'longitude': 'Must be between -180.0 and 180.0'}`

The reference for what the how the API formats error messages is [here](https://developer.uber.com/docs/rides/api-reference#errors).

I've already signed the CLA, let me know if you have any comments, suggestions, or issues.
